### PR TITLE
Patch to solve issue #8

### DIFF
--- a/src/SparkFunLSM6DS3.cpp
+++ b/src/SparkFunLSM6DS3.cpp
@@ -869,6 +869,6 @@ uint16_t LSM6DS3::fifoGetStatus( void ) {
 }
 void LSM6DS3::fifoEnd( void ) {
 	// turn off the fifo
-	writeRegister(LSM6DS3_ACC_GYRO_FIFO_STATUS1, 0x00);  //Disable
+	writeRegister(LSM6DS3_ACC_GYRO_FIFO_CTRL5, 0x00);  //Disable
 }
 


### PR DESCRIPTION
Corrected the register to disable the fifo buffer in the function fifoEnd(). See page 49 and 50 of LSM6DS3 datasheet.
This change fix the issue #8 