### PR TITLE
Bump version to 1.0.1 in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun LSM6DS3 Breakout
-version=1.0.0
+version=1.0.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=A library to drive the STmicro LSM6DS3 by SPI or I2C.


### PR DESCRIPTION
The "Library Manager" still picks up the older version 1.0.0.
I think this is because the `library.properties` file was not update to "1.0.1" yet (assuming I did not miss anything else).
This PR updates it.