### PR TITLE
Fix issue with compilation for ESP8266

### DIFF
--- a/src/SparkFunLSM6DS3.cpp
+++ b/src/SparkFunLSM6DS3.cpp
@@ -77,8 +77,6 @@ status_t LSM6DS3Core::beginCore(void)
 		// Data is read and written MSb first.
 #ifdef ESP32
 		SPI.setBitOrder(SPI_MSBFIRST);
-#elif ESP8266
-		SPI.setBitOrder(SPI_MSBFIRST);
 #else
 		SPI.setBitOrder(MSBFIRST);
 #endif


### PR DESCRIPTION
Remove ESP8266 case for SPI.setBitOrder to fix compilation issue with latest version of esp8266 (2.6.3).
The ESP8266 SPI library uses MSBFIRST instead of SPI_MSBFIRST