### PR TITLE
correct Temperature Readings

### DIFF
--- a/src/SparkFunLSM6DS3.cpp
+++ b/src/SparkFunLSM6DS3.cpp
@@ -753,7 +753,8 @@ int16_t LSM6DS3::readRawTemp( void )
 
 float LSM6DS3::readTempC( void )
 {
-	float output = (float)readRawTemp() / 16; //divide by 16 to scale
+	//float output = (float)readRawTemp() / 16; //divide by 16 to scale
+	float output = (float)readRawTemp() / 256; //divide by 256 to scale: Application Note AN5130 Chapter 9 256LSB/°C
 	output += 25; //Add 25 degrees to remove offset
 
 	return output;
@@ -762,7 +763,8 @@ float LSM6DS3::readTempC( void )
 
 float LSM6DS3::readTempF( void )
 {
-	float output = (float)readRawTemp() / 16; //divide by 16 to scale
+	//float output = (float)readRawTemp() / 16; //divide by 16 to scale = Wrong
+	float output = (float)readRawTemp() / 256; //divide by 256 to scale: Application Note AN5130 Chapter 9 256LSB/°C
 	output += 25; //Add 25 degrees to remove offset
 	output = (output * 9) / 5 + 32;
 


### PR DESCRIPTION
As stated in Application Note AN5130 Chapter 9: 
The temperature sensor has a sensitivity of 256LSB/°C. 
Therefore the Value must be devided by 256 to get the correct readings. 
In the old code it was divided by 16 and therefore the readout Temperature values are wrong. https://www.st.com/resource/en/application_note/an5130-lsm6ds3trc-alwayson-3d-accelerometer-and-3d-gyroscope-stmicroelectronics.pdf