### PR TITLE
Fix SPI setting for Arduino Uno

### DIFF
--- a/src/SparkFunLSM6DS3.cpp
+++ b/src/SparkFunLSM6DS3.cpp
@@ -86,6 +86,9 @@ status_t LSM6DS3Core::beginCore(void)
 #ifdef ARDUINO_NANO33BLE
     mySpiSettings = SPISettings(spiPortSpeed, MSB_FIRST, SPI_MODE0);
 #endif
+#ifdef ARDUINO_AVR_UNO
+	mySpiSettings = SPISettings(spiPortSpeed, MSBFIRST, SPI_MODE1);
+#endif
 
 		pinMode(chipSelectPin, OUTPUT);
 		digitalWrite(chipSelectPin, HIGH);


### PR DESCRIPTION
Related to #27. Suspecting that all Arduino boards using AVR core should be changed, but for now only changed for Arduino Uno, as I read source code for Uno and tested on Arduino Uno boards.